### PR TITLE
SLING-9542, Unable to use junit categories with sling junit core

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -73,6 +73,8 @@
                             org.junit.rules.*;version=${junit.version},
                             org.junit.runner.*;version=${junit.version},
                             org.junit.runners.*;version=${junit.version},
+                            org.junit.experimental.categories.*;version=${junit.version},
+                            org.junit.validator.*;version=${junit.version},
                             org.hamcrest;version=${hamcrest.version},
                             org.hamcrest.*;version=${hamcrest.version}
                         </_exportcontents>


### PR DESCRIPTION
  - export org.junit.experimental.categories.* and
    org.junit.validator.*