### PR TITLE
SLING-12720 - Build fails on Java 21:Byte Buddy could not instrument all classes within the mock's type hierarchy

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -369,8 +369,8 @@
 
         <dependency>
             <groupId>org.mockito</groupId>
-            <artifactId>mockito-inline</artifactId>
-            <version>3.10.0</version>
+            <artifactId>mockito-core</artifactId>
+            <version>5.10.0</version>
             <scope>test</scope>
         </dependency>
 

--- a/src/it/annotations-it/src/test/java/org/apache/sling/junit/annotations/AnnotationsTestSupport.java
+++ b/src/it/annotations-it/src/test/java/org/apache/sling/junit/annotations/AnnotationsTestSupport.java
@@ -83,7 +83,12 @@ public class AnnotationsTestSupport extends TestSupport {
             mavenBundle().groupId("ch.qos.logback").artifactId("logback-core").versionAsInProject(),
             mavenBundle().groupId("org.ops4j.pax.logging").artifactId("pax-logging-api").versionAsInProject(),
             mavenBundle().groupId("org.ops4j.pax.logging").artifactId("pax-logging-logback").versionAsInProject(),
-            mavenBundle().groupId("jakarta.json").artifactId("jakarta.json-api").version("2.1.1")
+            mavenBundle().groupId("jakarta.json").artifactId("jakarta.json-api").version("2.1.1"),
+            mavenBundle().groupId("org.ow2.asm").artifactId("asm").version("9.7"),
+            mavenBundle().groupId("org.ow2.asm").artifactId("asm-analysis").version("9.7"),
+            mavenBundle().groupId("org.ow2.asm").artifactId("asm-commons").version("9.7"),
+            mavenBundle().groupId("org.ow2.asm").artifactId("asm-util").version("9.7"),
+            mavenBundle().groupId("org.ow2.asm").artifactId("asm-tree").version("9.7")
         );
     }
 


### PR DESCRIPTION
Update mockito and ASM to versions that support Java 21.